### PR TITLE
Abinit 9.6.2 cpegnu 21.08

### DIFF
--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-cpeGNU-21.08.eb
@@ -10,10 +10,31 @@ name = 'ABINIT'
 version = '9.6.2'
 
 homepage = 'https://www.abinit.org/'
-description = """ABINIT is a package whose main program allows one to find the total energy,
- charge density and electronic structure of systems made of electrons and nuclei (molecules
- and periodic solids) within Density Functional Theory (DFT), using pseudopotentials and a
- planewave or wavelet basis."""
+
+whatis = [
+    "ABINIT is a software suite to calculate the optical, mechanical, "
+    "vibrational, and other observable properties of materials"
+]
+
+description = """
+ABINIT is a software suite to calculate the optical, mechanical, vibrational, 
+and other observable properties of materials. Starting from the quantum 
+equations of density functional theory, you can build up to advanced 
+applications with perturbation theories based on DFT, and many-body Green's
+functions (GW and DMFT).
+
+ABINIT can calculate molecules, nanostructures and solids with any chemical 
+composition, and comes with several complete and robust tables of atomic 
+potentials.
+
+This module provides an pure MPI executable. It includes support for netCDF, 
+HDF5, LibXC functionals and Wannier90.
+"""
+
+docurls = [
+    'Documentation: https://docs.abinit.org/',
+    'Tutorials:  https://docs.abinit.org/tutorial/'
+]
 
 toolchain = {'name': 'cpeGNU', 'version': '21.08'}
 toolchainopts = {'usempi': True, 'pic': True, 'gfortran9-compat': True}

--- a/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/a/ABINIT/ABINIT-9.6.2-cpeGNU-21.08.eb
@@ -1,0 +1,78 @@
+# Based on work of  Matthias Kraushaar (CSCS)
+# Adapted for LUMI by Orian Louant
+
+local_libxc_version = '5.1.7'
+local_Wannier90_version = '3.1.0'
+
+easyblock = 'ConfigureMake'
+
+name = 'ABINIT'
+version = '9.6.2'
+
+homepage = 'https://www.abinit.org/'
+description = """ABINIT is a package whose main program allows one to find the total energy,
+ charge density and electronic structure of systems made of electrons and nuclei (molecules
+ and periodic solids) within Density Functional Theory (DFT), using pseudopotentials and a
+ planewave or wavelet basis."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.08'}
+toolchainopts = {'usempi': True, 'pic': True, 'gfortran9-compat': True}
+
+source_urls = ['https://www.abinit.org/sites/default/files/packages/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    'b018c2ff24338a5952c5550a7e09d4c7793b62402c7aa4e09273e9a666e674fb'
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True),
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('libxc',                    local_libxc_version),
+    ('Wannier90',                local_Wannier90_version),
+    ('cray-fftw',                EXTERNAL_MODULE),
+    ('cray-hdf5-parallel',       EXTERNAL_MODULE),
+    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
+]
+
+configopts  = 'FCFLAGS="-ffree-line-length-none $FCFLAGS" '
+configopts += 'FFLAGS=" $FFLAGS" '
+
+# Ensure MPI
+configopts += ' --with-mpi="yes" '
+configopts += ' --enable-mpi-io="yes" '
+configopts += ' FC="ftn" CC="cc" CXX="CC" F90="ftn" '
+
+# FFTW
+configopts += ' --with-fft-flavor=fftw3 FFTW3_LIBS="-L${FFTW_ROOT} -lfftw3f -lfftw3" '
+
+# Linear Algebra
+configopts += ' --with-linalg-flavor=netlib '
+configopts += ' LINALG_LIBS="-L${CRAY_LIBSCI_PREFIX_DIR}/lib/ -lsci_gnu_mpi" '
+configopts += ' LINALG_LDFLAGS="-L${CRAY_LIBSCI_PREFIX_DIR}/lib/ -lsci_gnu_mpi" '
+configopts += ' LINALG_FCFLAGS="-I${CRAY_LIBSCI_PREFIX_DIR}/include" '
+
+# libxc support
+configopts += ' --with-libxc=${EBROOTLIBXC} '
+
+# hdf5/netcdf4 support
+configopts += ' --with-netcdf="${CRAY_NETCDF_HDF5PARALLEL_PREFIX}" '
+configopts += ' --with-netcdf-fortran="${CRAY_NETCDF_HDF5PARALLEL_PREFIX}" '
+configopts += ' --with-hdf5="${CRAY_HDF5_PARALLEL_PREFIX}" '
+
+# Wannier90
+configopts += ' --with-wannier90="${EBROOTWANNIER90}" '
+preconfigopts = 'export WANNIER90_LIBS="-L$EBROOTWANNIER90/lib -lwannier" && '
+
+# 'make check' is just executing some basic unit tests.
+# Also running 'make tests_v1' to have some basic validation
+runtest = "check && make test_v1"
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['abinit', 'aim', 'cut3d', 'conducti', 'mrgddb', 'mrgscr', 'optic']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/ABINIT/README.md
+++ b/easybuild/easyconfigs/a/ABINIT/README.md
@@ -1,0 +1,47 @@
+# Abinit
+
+[Abinit home page](https://www.abinit.org/)
+
+## General information
+
+ABINIT is a software suite to calculate the optical, mechanical, vibrational, 
+and other observable properties of materials. Starting from the quantum 
+equations of density functional theory, you can build up to advanced 
+applications with perturbation theories based on DFT, and many-body Green's
+functions (GW and DMFT).
+
+ABINIT can calculate molecules, nanostructures and solids with any chemical 
+composition, and comes with several complete and robust tables of atomic 
+potentials.
+
+  * [Abinit documentation](https://docs.abinit.org/)
+  * [Abinit tutorials](https://docs.abinit.org/tutorial/)
+
+## EasyBuild
+
+  * [Abinit in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/a/ABINIT)
+  * [Abinit in the CSCS repository](https://github.com/easybuilders/CSCS/tree/master/easybuild/easyconfigs/a/ABINIT)
+
+### Abinit 9.6.2 from CPE 21.08 on LUMI
+
+Adapted from CSCS Easyconfig:
+  
+  * Add configuration options to make sure that Cray LibSci is used
+  * Enable MPI I/O
+
+#### About enabling OpenMP
+
+Enabling OpenMP has been tested but results in a Segmentation Fault at the end
+of the runs:
+
+```
+Thread 1 "abinit" received signal SIGSEGV, Segmentation fault.
+0x00007fffef21258d in __freeBlasMemPool () from /opt/cray/pe/lib64/libsci_gnu_82_mp.so.5
+```
+
+Setting the stack size to `unlimited` command or setting the environment 
+variable `CRAYBLAS_ALLOC_TYPE=2` or `CRAYBLAS_FORCE_HEAP_ALLOC=1` as recommended
+by Cray solve this problem. 
+
+While the program runs fine this error at the end may confuse users. OpenMP is
+thus disabled at the moment.

--- a/easybuild/easyconfigs/l/libxc/README.md
+++ b/easybuild/easyconfigs/l/libxc/README.md
@@ -1,0 +1,12 @@
+# Libxc
+
+[Libxc website](https://www.tddft.org/programs/libxc/)
+
+## General information
+
+Libxc is a library of exchange-correlation and kinetic energy functionals for 
+density-functional theory. The original aim was to provide a portable, well 
+tested and reliable set of LDA, GGA, and meta-GGA  functionals.
+
+  * [Libxc documentation](https://www.tddft.org/programs/libxc/manual/)
+  * [Available functionals](https://www.tddft.org/programs/libxc/functionals/)

--- a/easybuild/easyconfigs/l/libxc/libxc-5.1.7-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-5.1.7-cpeGNU-21.08.eb
@@ -8,9 +8,32 @@ easyblock = 'CMakeMake'
 name = 'libxc'
 version = '5.1.7'
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
-description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
- The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+homepage = 'https://www.tddft.org/programs/libxc/'
+
+whatis = [
+    "Libxc is a library of exchange-correlation and kinetic energy functionals " 
+    "for density-functional theory."
+]
+
+description = """
+Libxc is a library of exchange-correlation and kinetic energy functionals for 
+density-functional theory. The original aim was to provide a portable, well 
+tested and reliable set of LDA, GGA, and meta-GGA functionals.
+
+Libxc is written in C, but it also comes with Fortran binding. 
+
+It is released under the MPL license (v. 2.0). In all publications resulting 
+from your use of Libxc, please cite:
+
+[ref] Susi Lehtola, Conrad Steigemann, Micael J. T. Oliveira, and Miguel A. L. Marques, 
+      "Recent developments in Libxc - A comprehensive  library of functionals for 
+      density functional theory", Software X 7, 1 (2018)
+"""
+
+docurls = [
+    'Manual: https://www.tddft.org/programs/libxc/manual/',
+    'Available functionals: https://www.tddft.org/programs/libxc/functionals/'
+]
 
 toolchain = {'name': 'cpeGNU', 'version': '21.08'}
 toolchainopts = {'opt': True}

--- a/easybuild/easyconfigs/l/libxc/libxc-5.1.7-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-5.1.7-cpeGNU-21.08.eb
@@ -1,0 +1,36 @@
+# contributed by Luca Marsella (CSCS)
+# adapated for LUMI by Orian Louant
+
+local_bzip2_version = '1.0.8'
+
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '5.1.7'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.08'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
+sources = [SOURCE_TAR_BZ2]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True), # For CMake
+    ('bzip2',      local_bzip2_version),
+]
+
+configopts = [
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib ",
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib  -DBUILD_SHARED_LIBS=ON ",
+]
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 'lib/%(name)sf90.a', 'lib/%(name)sf90.so', 'lib/%(name)sf03.a', 'lib/%(name)sf03.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/w/Wannier90/README.md
+++ b/easybuild/easyconfigs/w/Wannier90/README.md
@@ -1,0 +1,11 @@
+# Wannier90
+
+[Wannier website](http://www.wannier.org/)
+
+## General information
+
+Wannier90 is an open-source code (released under GPLv2) for generating 
+maximally-localized Wannier functions and using them to compute advanced 
+electronic properties of materials with high efficiency and accuracy.
+
+  * [Wannier user guide and tutorial](http://www.wannier.org/support/)

--- a/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-cpeGNU-21.08.eb
@@ -6,7 +6,32 @@ name = 'Wannier90'
 version = '3.1.0'
 
 homepage = 'http://www.wannier.org'
-description = """A tool for obtaining maximally-localised Wannier functions"""
+
+whatis = [
+    'Wannier90 is a code for generating maximally-localized Wannier functions'
+]
+
+description = """
+Wannier90 is an open-source code (released under GPLv2) for generating 
+maximally-localized Wannier functions and using them to compute advanced 
+electronic properties of materials with high efficiency and accuracy.
+
+Many electronic structure codes have an interface to Wannier90, including 
+Quantum ESPRESSO, Abinit, VASP, Siesta, Wien2k, Fleur, OpenMX and GPAW; and 
+there are several post-processing codes that are able to use the output of 
+Wannier90 for further analysis and calculation.
+
+In all publications resulting from your use of Wannier90, please cite:
+
+[ref] "Wannier90 as a community code: new features and applications", 
+      G. Pizzi et al., J. Phys. Cond. Matt. 32, 165902 (2020)
+
+This module was build with with MPI support.
+"""
+
+docurls = [
+    'User guide and tutorial:  http://www.wannier.org/support/'
+]
 
 toolchain = {'name': 'cpeGNU', 'version': '21.08'}
 toolchainopts = {'usempi': True, 'gfortran9-compat': True}

--- a/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-cpeGNU-21.08.eb
@@ -1,0 +1,37 @@
+# adapted for LUMI by Orian Louant
+
+easyblock = 'MakeCp'
+
+name = 'Wannier90'
+version = '3.1.0'
+
+homepage = 'http://www.wannier.org'
+description = """A tool for obtaining maximally-localised Wannier functions"""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.08'}
+toolchainopts = {'usempi': True, 'gfortran9-compat': True}
+
+github_account = 'wannier-developers'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [{'download_filename': 'v%(version)s.tar.gz', 'filename': SOURCELOWER_TAR_GZ}]
+patches = ['Wannier90_3x_ignore_makeinc.patch']
+checksums = [
+    '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254',  # wannier90-3.1.0.tar.gz
+    '561c0d296e0e30b8bb303702cd6e41ded54c153d9b9e6cd9cab73858e5e2945e',  # Wannier90_3x_ignore_makeinc.patch
+]
+
+builddependencies = [
+    ('buildtools', '%(toolchain_version)s', '', True)
+]
+
+buildopts  = 'all F90=$F90 MPIF90=$MPIF90 FCOPTS="$FFLAGS" LDOPTS="$FFLAGS" '
+buildopts += 'COMMS=mpi'
+
+files_to_copy = [(['wannier90.x', 'postw90.x'], 'bin'), (['libwannier.a'], 'lib')]
+
+sanity_check_paths = {
+    'files': ['bin/wannier90.x', 'bin/postw90.x', 'lib/libwannier.a'],
+    'dirs': []
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Abinit with LibXC and Wannier90, MPI enabled, cpeGNU 21.08

Enabling OpenMP has been tested but results in a Segmentation Fault at the end
of the runs:

```
Thread 1 "abinit" received signal SIGSEGV, Segmentation fault.
0x00007fffef21258d in __freeBlasMemPool () from /opt/cray/pe/lib64/libsci_gnu_82_mp.so.5
```

Setting the stack size to `unlimited` command or setting the environment 
variable `CRAYBLAS_ALLOC_TYPE=2` or `CRAYBLAS_FORCE_HEAP_ALLOC=1` as recommended
by Cray solve this problem. 

While the program runs fine this error at the end may confuse users. OpenMP is
thus disabled at the moment.