### PR TITLE
Feature/eap easy build

### DIFF
--- a/CrayPE/CPEpackages_21.08.csv
+++ b/CrayPE/CPEpackages_21.08.csv
@@ -33,7 +33,7 @@ cray-python,3.8.5.1
 cray-R,4.0.5.1
 jemalloc,5.1.0.4
 AOCC,3.0.0
-ROCM,4.0.1
+ROCM,4.5.2
 intel,2021.2
 NVIDIA,20.9
 craype-targets,1.5.0

--- a/CrayPE/CPEpackages_21.12.csv
+++ b/CrayPE/CPEpackages_21.12.csv
@@ -35,7 +35,7 @@ cray-python,3.9.4.2
 cray-R,4.1.1.1
 jemalloc,5.1.0.4
 AOCC,3.1.0
-ROCM,4.3.0
+ROCM,4.5.2
 intel,2021.4.0
 NVIDIA,21.3
 craype-targets,1.7.0

--- a/easybuild/easyconfigs/r/rocm/rocm-4.3.1.eb
+++ b/easybuild/easyconfigs/r/rocm/rocm-4.3.1.eb
@@ -1,0 +1,74 @@
+# Created for LUMI by Orian Louant
+#
+# This is not very clean but it do the job. Tried with a bundle EasyBlock without
+# much success: Esybuild tried to uncompress the RPMs as they were Tarballs.
+
+easyblock = 'Bundle'
+
+name = 'rocm'
+version = '4.3.1'
+
+homepage = 'https://rocmdocs.amd.com/'
+
+whatis = [
+    "Description: AMD ROCm is the first open-source software development platform for "
+    "HPC/Hyperscale-class GPU computing"
+]
+
+description = """
+AMD ROCm is the first open-source software development platform for 
+HPC/Hyperscale-class GPU computing. AMD ROCm brings the UNIX philosophy of 
+choice, minimalism and modular software development to GPU computing.
+
+ROCm provides tools the tools required for the development of code using HIP, 
+OpenCL and OpenMP programming models including tools for profiling and 
+debugging.
+
+This is an experimental module provided for the convenience of the Early Access
+Platform so that they can compile their code from the login node. Problems can
+and will occur and we can only offer limited support. The module should be
+used with the compilers from the Cray Programming Environment 21.08.
+"""
+
+docurls = [
+  'https://docs.lumi-supercomputer.eu/eap/',
+  'https://rocmdocs.amd.com/en/latest/'
+]
+
+toolchain = SYSTEM
+
+local_rocm_root = '/opt/rocm-' + version
+
+allow_prepend_abs_path = True
+
+modextrapaths = {
+  'CPATH'              : ['%s/include' % local_rocm_root,
+                          '%s/llvm/include' % local_rocm_root],
+  'C_INCLUDE_PATH'     : '%s/llvm/include' % local_rocm_root,
+  'CPLUS_INCLUDE_PATH' : '%s/llvm/include' % local_rocm_root,
+  'PATH'               : ['%s' % local_rocm_root, 
+                          '%s/hip/bin' % local_rocm_root, 
+                          '%s/llvm/bin' % local_rocm_root],
+  'LD_LIBRARY_PATH'    : ['%s/lib' % local_rocm_root, 
+                          '%s/lib64' % local_rocm_root,
+                          '%s/hsa/lib' % local_rocm_root, 
+                          '%s/llvm/lib' % local_rocm_root],
+  'LIBRARY_PATH'       : ['%s/lib' % local_rocm_root, 
+                          '%s/lib64' % local_rocm_root,
+                          '%s/hsa/lib' % local_rocm_root, 
+                          '%s/llvm/lib' % local_rocm_root],
+  'MANPATH'             : '%s/share/man' % local_rocm_root,
+  'PKG_CONFIG_PATH'     : '%s/share/pkgconfig' % local_rocm_root,
+  'XDG_DATA_DIRS'       : '%s/share' % local_rocm_root,
+  'CMAKE_PREFIX_PATH'   : local_rocm_root,
+  'CMAKE_LIBRARY_PATH'  : '%s/lib64' % local_rocm_root,
+}
+
+modextravars = {
+  'ROCM_PATH'    : local_rocm_root,
+  'HIP_PATH'     : '%s/hip' % local_rocm_root,
+  'HIP_LIB_PATH' : '%s/hip/lib' % local_rocm_root,
+  'HSA_PATH'     : '%s/hsa' % local_rocm_root,
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Create a fake module for ROCM 4.3.1; changes to the CPE component files to use ROCm 4.5.2.