### PR TITLE
Fix link in SitePackage.lua to correct page

### DIFF
--- a/LMOD/SitePackage.lua
+++ b/LMOD/SitePackage.lua
@@ -714,7 +714,7 @@ local function msg_hook(mode, output)
     dbg.print{"Mode is ", mode, "\n"}
 
     if mode == "avail" then
-        local spiderdoc_url = 'https://docs.lumi-supercomputer.eu/computing/Lmod_modules/'
+        local spiderdoc_url = 'https://docs.lumi-supercomputer.eu/runjobs/lumi_env/Lmod_modules/'
         local request_url   = 'https://lumi-supercomputer.eu/user-support/need-help/'
         output[#output+1]   = '\nAdditional ways to search for software:\n'
         output[#output+1]   = '* Use "module spider" to find all possible modules and extensions.\n'


### PR DESCRIPTION
Current version points to  https://docs.lumi-supercomputer.eu/computing/Lmod_modules/ which is deprecated. New link is https://docs.lumi-supercomputer.eu/runjobs/lumi_env/Lmod_modules/