### PR TITLE
Update lumi-workspaces for flash quota

### DIFF
--- a/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.1.eb
+++ b/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.1.eb
@@ -40,7 +40,6 @@ set -o nounset
 declare -A offsets=( ["users"]="1000000000" \
                               ["projappl"]="2000000000" \
                               ["scratch"]="3000000000" \
-                              ["flash"]="3000000000" \
                    )
 
 # User specific values
@@ -139,7 +138,6 @@ function print_projects() {
         echo
         print_quota projappl ${grp}
         print_quota scratch ${grp}
-        print_quota flash ${grp}
     done
 }
 

--- a/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.1.eb
+++ b/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.1.eb
@@ -40,6 +40,7 @@ set -o nounset
 declare -A offsets=( ["users"]="1000000000" \
                               ["projappl"]="2000000000" \
                               ["scratch"]="3000000000" \
+                              ["flash"]="3000000000" \
                    )
 
 # User specific values
@@ -138,6 +139,7 @@ function print_projects() {
         echo
         print_quota projappl ${grp}
         print_quota scratch ${grp}
+        print_quota flash ${grp}
     done
 }
 

--- a/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.2.eb
+++ b/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.2.eb
@@ -140,7 +140,9 @@ function print_projects() {
         echo
         print_quota projappl ${grp}
         print_quota scratch ${grp}
-        print_quota flash ${grp}
+        if [[ -d "/flash/${grp}" ]]; then
+             print_quota flash ${grp}
+        fi
     done
 }
 

--- a/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.2.eb
+++ b/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.2.eb
@@ -1,0 +1,228 @@
+# Contributed by Kurt Lust for the LUMI project
+
+easyblock = 'Bundle'
+
+name =    'lumi-workspaces'
+version = '0.1'
+
+homepage = ''
+
+whatis = [
+    'Description: Provides the lumi-workspaces command to check your quota on LUMI.'
+]
+
+description = """
+This module provides the lumi-workspaces command to check your quota on LUMI.
+"""
+
+usage = """
+The lumi-workspaces command comes in three different forms:
+  * lumi-workspaces         : Shows your workspaces
+  * lumi-workspaces -v      : Detailed quota information
+  * lumi-workspaces -p prj  : Show quota of project prj
+"""
+
+toolchain = SYSTEM
+
+local_workspaces_script = """#!/bin/bash
+
+# Exit on errors, exit when accessing undefined variables
+set -o errexit
+set -o nounset
+#set -o xtrace
+
+#----------------------------------------------------------------------
+# Global variable declarations
+#----------------------------------------------------------------------
+
+# Set needed variables
+# Lustre project id mappings offsets
+declare -A offsets=( ["users"]="1000000000" \
+                              ["projappl"]="2000000000" \
+                              ["scratch"]="3000000000" \
+                              ["flash"]="3000000000" \
+                   )
+
+# User specific values
+username=$(whoami)
+uid=$(id -u ${username})
+homedir="/users/${username}"
+
+# Active groups with scratch folder
+active_groups=()
+
+# Output formatting strings
+desc_format="%-40s %8s/%-6s %8s/%s"
+long_format="%-40s %8s %5s %5s %5s %5s %5s"
+
+# Formatting used, default is desc, option -v sets this to long
+formatting=desc
+
+# Are we printing just a single project info (option -p)?
+single_project=false
+
+#----------------------------------------------------------------------
+# Function declarations
+#----------------------------------------------------------------------
+
+# Usage
+function usage() {
+    echo "This help script is used to manage your workspaces"
+    echo " $(basename $0)          : Shows your workspaces"
+    echo " $(basename $0) -v       : Detailed quota information"
+    echo " $(basename $0) -p prj   : Show quota of project prj"
+    exit 0
+}
+
+# Quota query function
+# Arguments: 1. Lustre project id
+#            2. Directory
+function quotaquery() {
+    local quota=$(lfs quota -q -p ${1} ${2} 2> /dev/null)
+    if [[ "${quota[@]}" == *"errors happened"* ]]; then
+        echo "${2}:  Errors while reading quota (permission denied?)"
+        exit 1
+    fi
+    case "${formatting}" in
+        desc)
+            IFS=' '; local values=($quota); unset IFS
+            printf "${desc_format}" \
+                   ${2} \
+                   $(numfmt --to si --from iec ${values[1]%\*}K) \
+                   $(numfmt --to si --from iec ${values[2]%\*}K) \
+                   $(numfmt --to si ${values[5]%\*}) \
+                   $(numfmt --to si ${values[6]%\*})
+            ;;
+        long)
+            IFS=' '; local values=($quota); unset IFS
+            printf "${long_format}" \
+                   ${values[0]} \
+                   $(numfmt --to si --from iec ${values[1]%\*}K) \
+                   $(numfmt --to si --from iec ${values[2]%\*}K) \
+                   $(numfmt --to si --from iec ${values[3]%\*}K) \
+                   $(numfmt --to si ${values[5]%\*}) \
+                   $(numfmt --to si ${values[6]%\*}) \
+                   $(numfmt --to si ${values[7]%\*})
+            ;;
+    esac
+}
+
+# Print separator line
+function print_line() {
+    case "${formatting}" in
+        desc)
+            echo "----------------------------------------------------------------------"
+            ;;
+        long)
+            echo "-------------------------------------------------------------------------------"
+    esac
+}
+
+# Print project quota
+# Arguments: 1. disk area (scratch or projappl), these have to be also valid
+#               keys in offsets array
+#            2. project
+function print_quota() {
+    local gid=$(getent group ${2} | cut -d : -f3)
+
+    if [[ -d "/${1}/${2}" ]]; then
+        echo "$(quotaquery $(( ${gid} + ${offsets[${1}]} )) /${1}/${2})"
+    fi
+}
+
+# Print all active projects
+# Arguments: 1... list of active projects
+function print_projects() {
+    for grp in "${@}"; do
+        print_line
+        echo "Project: ${grp}"
+        echo
+        print_quota projappl ${grp}
+        print_quota scratch ${grp}
+        print_quota flash ${grp}
+    done
+}
+
+# Print home directory quota
+function print_home() {
+    print_line
+    echo "Personal home folder"
+    echo
+    echo "$(quotaquery $(( ${uid} + ${offsets[users]} )) ${homedir} ${1})"
+}
+
+#----------------------------------------------------------------------
+# Main script execution
+#----------------------------------------------------------------------
+
+# Fill in the active project info
+# Each FMI project has a symlink in /scratch folder
+my_groups=$(groups)
+# DEBUG projects my_groups="ilvonens p_installation_spack project_2001659 project_2001981 project_2003573"
+
+# Process arguments
+while getopts "p:hv" arg; do
+    case "$arg" in
+        h*)
+            usage
+            ;;
+        p)
+            my_groups=(${OPTARG})
+            single_project=true
+            ;;
+        v)
+            formatting="long"
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Filter active projects, they should have /scratch folder
+for g in ${my_groups}; do
+    if [[ -d "/scratch/${g}" ]]; then
+        active_groups+=(${g})
+    fi
+done
+
+# Check that the -p argument is actually an active project
+if [[ "${single_project:-false}" == "true" && ! -d "/scratch/${my_groups[0]}" ]]; then
+    echo "${my_groups[@]} is not an active project with quota"
+    exit 1
+fi
+
+# Print the description line
+case "${formatting}" in
+    desc)
+        echo ;
+        echo "Disk area                          Capacity(used/max)  Files(used/max)"
+        ;;
+    long)
+        echo ;
+        printf "${long_format}" "Filesystem" "Used" "Quota" "Limit" "Files" "Quota" "Limit"
+        echo ;
+        ;;
+esac
+
+if [[ "${single_project:-false}" == "false" ]];  then
+    print_home desc
+fi
+print_projects "${active_groups[@]}"
+print_line
+"""
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/bin',
+    'cd %(installdir)s/bin ; cat >lumi-workspaces <<EOF\n' + local_workspaces_script.replace('$', '\$') + '\nEOF\n'
+    'cd %(installdir)s/bin ; chmod a+rx lumi-workspaces'
+]
+
+sanity_check_paths = {
+    'files': ['bin/lumi-workspaces'],
+    'dirs':  []
+}
+
+sanity_check_commands = [
+    'lumi-workspaces -h'
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.2.eb
+++ b/easybuild/easyconfigs/l/lumi-workspaces/lumi-workspaces-0.2.eb
@@ -1,9 +1,10 @@
 # Contributed by Kurt Lust for the LUMI project
+# Original script created by Sami Ilvonens (CSC)
 
 easyblock = 'Bundle'
 
 name =    'lumi-workspaces'
-version = '0.1'
+version = '0.2'
 
 homepage = ''
 
@@ -156,7 +157,6 @@ function print_home() {
 #----------------------------------------------------------------------
 
 # Fill in the active project info
-# Each FMI project has a symlink in /scratch folder
 my_groups=$(groups)
 # DEBUG projects my_groups="ilvonens p_installation_spack project_2001659 project_2001981 project_2003573"
 


### PR DESCRIPTION
Small change to the `lumi-workspaces-0.1.eb` to print `/flash/` quota.

- `/flash/` is a separate filesystem so the `offset` is the same as `scratch`, this may change. 
- There are some issues with `lfs quota` for `/flash/` currently (instability) so maybe merge this when they have been resolved. 
- Should a sanity check be added to only print `/flash/` quota if they are in a project with access to `/flash/`? 
- Should `lumi-workspaces-0.1.eb` be kept the same and instead create a `lumi-workspaces-0.2.eb`? Then in the next SW stack update move to using `lumi-workspaces/0.2`? 

Thanks!