### PR TITLE
LUMI-O

### DIFF
--- a/easybuild/easyconfigs/l/lumio-ext-tools/LICENSE.md
+++ b/easybuild/easyconfigs/l/lumio-ext-tools/LICENSE.md
@@ -1,0 +1,20 @@
+# License information for lumio-ext-tools
+
+rclone is distributed under an MIT license
+a copy of which can be found in the
+[COPYING file in the rclone GitHub repository](https://github.com/rclone/rclone/blob/master/COPYING).
+
+restic is distributed under a
+BSD 2-Clause "Simplified" License
+a copy of which can be found in the 
+[LICENSE file in the restic GitHub repository](https://github.com/restic/restic/blob/master/LICENSE).
+
+s3cmd is licensed under the 
+GNU General Public License version 2.0
+a copy of which can be found in the 
+[LICENSE file in the s3cmd GitHub repository](https://github.com/s3tools/s3cmd/blob/master/LICENSE).
+
+As a dependency of s3cmd the python-magic package is also installed which is also
+licensed under an MIT license. A copy of the license and further copyright notices
+can be found in the 
+[LICENSE file in the python-magic GitHub repository](https://github.com/ahupp/python-magic/blob/master/LICENSE).

--- a/easybuild/easyconfigs/l/lumio-ext-tools/README.md
+++ b/easybuild/easyconfigs/l/lumio-ext-tools/README.md
@@ -1,0 +1,73 @@
+# lumio-ext-tools technical documentation
+
+This is a bundle of tools:
+
+-   rclone:
+
+    -   [rclone home page](https://rclone.org/)
+    
+        -   [Downloads on that site for version check](https://rclone.org/downloads/)
+        
+    -   [rclone on GitHub](https://github.com/rclone/rclone)
+    
+-   restic
+
+    -   [restic home page](https://restic.net/)
+    
+    -   [restic on GitHub](https://github.com/restic/restic)
+    
+        -   [GitHub releases](https://github.com/restic/restic/releases)
+
+-   s3cmd:
+
+    -   [s3cmd web site](https://s3tools.org/s3cmd)
+    
+    -   [s3cmd on GitHub](https://github.com/s3tools/s3cmd)
+
+    -   [s3cmd on PyPI](https://pypi.org/project/s3cmd/) 
+    
+    
+## EasyBuild
+
+-   rclone
+
+    -   [rclone support in the EasyBuilders repository](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/r/rclone)
+        This easyconfig compiles `rclone` from sources but requires Go to do so.
+        
+    -   There is no support for rclone in the CSCS repository
+    
+    -   [rclone support in Spack](https://spack.readthedocs.io/en/latest/package_list.html#rclone)
+    
+-   restic
+    
+    -    There is no support for restic in the EasyBuilders repository
+    
+    -    There is no support for restic in the CSCS repository
+    
+    -    [restic support in Spack](https://spack.readthedocs.io/en/latest/package_list.html#restic)
+    
+-   s3cmd
+
+    -    There is no support for s3cmd in the EasyBuilders repository
+    
+    -    There is no support for s3cmd in the EasyBuilders repository
+    
+    -    [py-s3cmd support in Spack](https://spack.readthedocs.io/en/latest/package_list.html#py-s3cmd)
+
+
+
+### Version 1.0.0
+
+-   The EasyConfig is a development of CSC and LUST.
+
+-   All binaries are installed from binary distributions.
+
+-   s3cmd:
+
+    -   Use the system Python
+    
+    -   Patched the s3cmd script so that the system Python is hard-code
+        and PYTHONPATH doesn't need to be set so that the tool can work
+        together with other tools on the system, also tools that would use
+        a different Python version.
+

--- a/easybuild/easyconfigs/l/lumio-ext-tools/USER.md
+++ b/easybuild/easyconfigs/l/lumio-ext-tools/USER.md
@@ -1,0 +1,5 @@
+# lumio-ext-tools user documentation
+
+This module is of little use without the 
+[lumio](../lumio/) module which provides the
+authentication script that is needed to generate the keys to access LUMI-O.

--- a/easybuild/easyconfigs/l/lumio-ext-tools/lumio-ext-tools-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio-ext-tools/lumio-ext-tools-1.0.0.eb
@@ -1,78 +1,95 @@
-# 
+# Written by Henrik Nortamo for the LUMI project
 easyblock = 'Bundle'
-name = 'lumio-ext-tools'
-version = "1.0.0"
+
+name =    'lumio-ext-tools'
+version = '1.0.0'
+
 homepage=""
-whatis = [ 'Description: Basic tooling for LUMI-O. Provides rclone,s3cmd and restic' ]
+
+whatis = [ 
+    'Description: Basic tooling for LUMI-O. Provides rclone, s3cmd and restic' 
+]
+
 description = """
-    Bundle of external tools used to access LUMI-O  
+Bundle of external tools used to access LUMI-O  
+
+This module is meant to be used with the `lumio` module which provides a tool
+for authentication.
 """ 
 
-moduleclass='tools'
-
-
 local_rclone_version = '1.61.1'
-local_s3cmd_version = '2.3.0'
+local_s3cmd_version =  '2.3.0'
 local_restic_version = '0.15.1'
 
+local_magic_version = '0.4.27' # Dependency for s3cmd that is not already on the system.
 
 toolchain = SYSTEM
+
 components=[
     # Static go built binary
-    ('rclone',local_rclone_version,{
-        'easyblock': 'MakeCp',
-        'source_urls' : ['https://downloads.%(name)s.org/v%(version)s/'],
-        'sources' :     ['%(name)s-v%(version)s-linux-amd64.zip'],
-        'checksums' :   ['6d6455e1cb69eb0615a52cc046a296395e44d50c0f32627ba8590c677ddf50a9'],
-        
-        'skipsteps' : ['build'],
-        
-        'files_to_copy' : [
-            (['%(name)s-v%(version)s-linux-amd64/rclone'],   'bin')
-        ],
-        
-        'sanity_check_paths' : {
-            'files': ['bin/rclone'],
-            'dirs':  []
-        },
-        
-        'sanity_check_commands' : [
-            'rclone --version'
-        ]
-
-
+    ('rclone', local_rclone_version,{
+        'easyblock':      'MakeCp',
+        'source_urls' :   ['https://downloads.%(name)s.org/v%(version)s/'],
+        'sources' :       ['%(name)s-v%(version)s-linux-amd64.zip'],
+        'checksums' :     ['6d6455e1cb69eb0615a52cc046a296395e44d50c0f32627ba8590c677ddf50a9'],
+        'skipsteps' :     ['build'],
+        'files_to_copy' : [(['%(name)s-v%(version)s-linux-amd64/rclone'],   'bin')],
     }),
     # Static go built binary
-    ('restic',local_restic_version, {
-        'easyblock': 'MakeCp',
-        'source_urls' : ['https://github.com/%(name)s/%(name)s/releases/download/v%(version)s/'],
-        'sources' :     ['%(name)s_%(version)s_linux_amd64.bz2'],
-        'checksums' :   ['3631e3c3833c84ba71f22ea3df20381676abc7476a7f6d14424d9abfada91414'],
-        'files_to_copy' : [
-            (['%(name)s_%(version)s_linux_amd64'],'bin')
-        ],
-        'skipsteps' : ['build'],
-        
-        'sanity_check_paths' : {
-            'files': ['bin/restic'], 
-            'dirs':  []
-        },
-        
-        'sanity_check_commands' : ['restic version']
+    ('restic', local_restic_version, {
+        'easyblock':      'MakeCp',
+        'source_urls' :   ['https://github.com/%(name)s/%(name)s/releases/download/v%(version)s/'],
+        'sources' :       ['%(name)s_%(version)s_linux_amd64.bz2'],
+        'checksums' :     ['3631e3c3833c84ba71f22ea3df20381676abc7476a7f6d14424d9abfada91414'],
+        'files_to_copy' : [(['%(name)s_%(version)s_linux_amd64'],'bin')],
+        'skipsteps' :     ['build'],
     }),
-    ('s3cmd',local_s3cmd_version,{
-       'easyblock': 'PythonPackage',
-        'source_urls': ['https://files.pythonhosted.org/packages/97/10/5ae9b5c69d0482dda2927c67a4db26a3e9e064964577a81be9239a419b3f/'],
-        'sources' :   ['%(name)s-%(version)s.tar.gz'],
-        'buildcmd': ' || cd %(name)s-%(version)s && python3 setup.py build', 
-        'install_target': ' || cd %(name)s-%(version)s && python3 setup.py install --prefix=%(installdir)s',
-    })
-    
-
+    ('python-magic', local_magic_version,{
+        'easyblock':      'PythonPackage',
+        'source_urls':    [PYPI_SOURCE],
+        'sources' :       ['%(name)s-%(version)s.tar.gz'],
+        'start_dir':      '%(namelower)s-%(version)s',
+        'req_py_majver':  3, # Used to let EasyBuild select the right system Python executable.
+        'req_py_minver':  6, # Used to let EasyBuild select the right system Python executable.
+    }),
+    ('s3cmd', local_s3cmd_version,{
+        'easyblock':      'PythonPackage',
+        'source_urls':    [PYPI_SOURCE],
+        'sources' :       ['%(name)s-%(version)s.tar.gz'],
+        'start_dir':      '%(namelower)s-%(version)s',
+        'req_py_majver':  3, # Used to let EasyBuild select the right system Python executable.
+        'req_py_minver':  6, # Used to let EasyBuild select the right system Python executable.
+    }),
 ]
 
 # Patch the s3cmd binary so that it does not rely on PYTHONPATH being set,
 local_patch_s3cmd = "--- s3cmd	2023-02-16 16:44:34.000000000 +0200\n+++ s3cmd_fixed	2023-02-16 16:45:09.000000000 +0200\n@@ -1,4 +1,8 @@\n #!/usr/bin/python3\n # EASY-INSTALL-SCRIPT: 's3cmd==2.3.0','s3cmd'\n+import pathlib\n+script_dir=pathlib.Path(__file__).parent.resolve()\n+import sys\n+sys.path.insert(0,str(script_dir) + f'/../lib/python{sys.version_info[0]}.{sys.version_info[1]}/site-packages/')\n __requires__ = 's3cmd==2.3.0'\n __import__('pkg_resources').run_script('s3cmd==2.3.0', 's3cmd')"
 
 # Probably not the right way to do this...
-postinstallcmds = [f'patch %(installdir)s/bin/s3cmd <(echo -e "{ local_patch_s3cmd }" )' ,'rm -f %(installdir)s/bin/s3cmd.orig','mv  %(installdir)s/bin/restic_0.15.1_linux_amd64 %(installdir)s/bin/restic && chmod +x %(installdir)s/bin/restic' ]
+postinstallcmds = [
+    f'patch %(installdir)s/bin/s3cmd <(echo -e "{ local_patch_s3cmd }" )' ,
+    'rm -f %(installdir)s/bin/s3cmd.orig',
+    'mv  %(installdir)s/bin/restic_0.15.1_linux_amd64 %(installdir)s/bin/restic && chmod +x %(installdir)s/bin/restic' 
+]
+
+sanity_check_paths = {
+    'files': [ 'bin/rclone', 'bin/restic', 'bin/s3cmd' ],
+    'dirs':  [ 'lib/python3.6/site-packages' ],    
+}
+
+sanity_check_commands = [
+    'rclone --version',
+    'restic version',
+    's3cmd --version',
+]
+
+moduleclass = 'tools'
+
+modluafooter = """
+extensions( "rclone/%(rclone)s", "restic/%(restic)s", "s3cmd/%(s3cmd)s" )
+""" % {
+    'rclone': local_rclone_version,
+    'restic': local_restic_version,
+    's3cmd':  local_s3cmd_version,
+}
+

--- a/easybuild/easyconfigs/l/lumio-ext-tools/lumio-ext-tools-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio-ext-tools/lumio-ext-tools-1.0.0.eb
@@ -1,0 +1,78 @@
+# 
+easyblock = 'Bundle'
+name = 'lumio-ext-tools'
+version = "1.0.0"
+homepage=""
+whatis = [ 'Description: Basic tooling for LUMI-O. Provides rclone,s3cmd and restic' ]
+description = """
+    Bundle of external tools used to access LUMI-O  
+""" 
+
+moduleclass='tools'
+
+
+local_rclone_version = '1.61.1'
+local_s3cmd_version = '2.3.0'
+local_restic_version = '0.15.1'
+
+
+toolchain = SYSTEM
+components=[
+    # Static go built binary
+    ('rclone',local_rclone_version,{
+        'easyblock': 'MakeCp',
+        'source_urls' : ['https://downloads.%(name)s.org/v%(version)s/'],
+        'sources' :     ['%(name)s-v%(version)s-linux-amd64.zip'],
+        'checksums' :   ['6d6455e1cb69eb0615a52cc046a296395e44d50c0f32627ba8590c677ddf50a9'],
+        
+        'skipsteps' : ['build'],
+        
+        'files_to_copy' : [
+            (['%(name)s-v%(version)s-linux-amd64/rclone'],   'bin')
+        ],
+        
+        'sanity_check_paths' : {
+            'files': ['bin/rclone'],
+            'dirs':  []
+        },
+        
+        'sanity_check_commands' : [
+            'rclone --version'
+        ]
+
+
+    }),
+    # Static go built binary
+    ('restic',local_restic_version, {
+        'easyblock': 'MakeCp',
+        'source_urls' : ['https://github.com/%(name)s/%(name)s/releases/download/v%(version)s/'],
+        'sources' :     ['%(name)s_%(version)s_linux_amd64.bz2'],
+        'checksums' :   ['3631e3c3833c84ba71f22ea3df20381676abc7476a7f6d14424d9abfada91414'],
+        'files_to_copy' : [
+            (['%(name)s_%(version)s_linux_amd64'],'bin')
+        ],
+        'skipsteps' : ['build'],
+        
+        'sanity_check_paths' : {
+            'files': ['bin/restic'], 
+            'dirs':  []
+        },
+        
+        'sanity_check_commands' : ['restic version']
+    }),
+    ('s3cmd',local_s3cmd_version,{
+       'easyblock': 'PythonPackage',
+        'source_urls': ['https://files.pythonhosted.org/packages/97/10/5ae9b5c69d0482dda2927c67a4db26a3e9e064964577a81be9239a419b3f/'],
+        'sources' :   ['%(name)s-%(version)s.tar.gz'],
+        'buildcmd': ' || cd %(name)s-%(version)s && python3 setup.py build', 
+        'install_target': ' || cd %(name)s-%(version)s && python3 setup.py install --prefix=%(installdir)s',
+    })
+    
+
+]
+
+# Patch the s3cmd binary so that it does not rely on PYTHONPATH being set,
+local_patch_s3cmd = "--- s3cmd	2023-02-16 16:44:34.000000000 +0200\n+++ s3cmd_fixed	2023-02-16 16:45:09.000000000 +0200\n@@ -1,4 +1,8 @@\n #!/usr/bin/python3\n # EASY-INSTALL-SCRIPT: 's3cmd==2.3.0','s3cmd'\n+import pathlib\n+script_dir=pathlib.Path(__file__).parent.resolve()\n+import sys\n+sys.path.insert(0,str(script_dir) + f'/../lib/python{sys.version_info[0]}.{sys.version_info[1]}/site-packages/')\n __requires__ = 's3cmd==2.3.0'\n __import__('pkg_resources').run_script('s3cmd==2.3.0', 's3cmd')"
+
+# Probably not the right way to do this...
+postinstallcmds = [f'patch %(installdir)s/bin/s3cmd <(echo -e "{ local_patch_s3cmd }" )' ,'rm -f %(installdir)s/bin/s3cmd.orig','mv  %(installdir)s/bin/restic_0.15.1_linux_amd64 %(installdir)s/bin/restic && chmod +x %(installdir)s/bin/restic' ]

--- a/easybuild/easyconfigs/l/lumio-ext-tools/lumio-ext-tools-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio-ext-tools/lumio-ext-tools-1.0.0.eb
@@ -17,6 +17,10 @@ This module is meant to be used with the `lumio` module which provides a tool
 for authentication.
 """ 
 
+docurls = [
+    'Manual pages for the rclone and s3cmd commands in section 1',
+]
+
 local_rclone_version = '1.61.1'
 local_s3cmd_version =  '2.3.0'
 local_restic_version = '0.15.1'
@@ -32,8 +36,11 @@ components=[
         'source_urls' :   ['https://downloads.%(name)s.org/v%(version)s/'],
         'sources' :       ['%(name)s-v%(version)s-linux-amd64.zip'],
         'checksums' :     ['6d6455e1cb69eb0615a52cc046a296395e44d50c0f32627ba8590c677ddf50a9'],
+        'start_dir':      '%(name)s-v%(version)s-linux-amd64',
         'skipsteps' :     ['build'],
-        'files_to_copy' : [(['%(name)s-v%(version)s-linux-amd64/rclone'],   'bin')],
+        #'files_to_copy' : [(['%(name)s-v%(version)s-linux-amd64/rclone'],   'bin'),
+        'files_to_copy' : [(['rclone'],   'bin'),
+                           (['rclone.1'], 'share/man/man1')],
     }),
     # Static go built binary
     ('restic', local_restic_version, {
@@ -62,14 +69,24 @@ components=[
     }),
 ]
 
-# Patch the s3cmd binary so that it does not rely on PYTHONPATH being set,
-local_patch_s3cmd = "--- s3cmd	2023-02-16 16:44:34.000000000 +0200\n+++ s3cmd_fixed	2023-02-16 16:45:09.000000000 +0200\n@@ -1,4 +1,8 @@\n #!/usr/bin/python3\n # EASY-INSTALL-SCRIPT: 's3cmd==2.3.0','s3cmd'\n+import pathlib\n+script_dir=pathlib.Path(__file__).parent.resolve()\n+import sys\n+sys.path.insert(0,str(script_dir) + f'/../lib/python{sys.version_info[0]}.{sys.version_info[1]}/site-packages/')\n __requires__ = 's3cmd==2.3.0'\n __import__('pkg_resources').run_script('s3cmd==2.3.0', 's3cmd')"
+# Replace the s3cmd script by one that does not rely on PYTHONPATH being set
+local_s3cmd = f"""#!/usr/bin/python3
+# EASY-INSTALL-SCRIPT: 's3cmd=={local_s3cmd_version}','s3cmd'
+import pathlib
+script_dir=pathlib.Path(__file__).parent.resolve()
+import sys
+sys.path.insert(0,str(script_dir) + f'/../lib/python{{sys.version_info[0]}}.{{sys.version_info[1]}}/site-packages/')
+__requires__ = 's3cmd=={local_s3cmd_version}'
+__import__('pkg_resources').run_script('s3cmd=={local_s3cmd_version}', 's3cmd')"""
 
 # Probably not the right way to do this...
 postinstallcmds = [
-    f'patch %(installdir)s/bin/s3cmd <(echo -e "{ local_patch_s3cmd }" )' ,
-    'rm -f %(installdir)s/bin/s3cmd.orig',
-    'mv  %(installdir)s/bin/restic_0.15.1_linux_amd64 %(installdir)s/bin/restic && chmod +x %(installdir)s/bin/restic' 
+    f'cat >%(installdir)s/bin/s3cmd <<EOF\n{local_s3cmd}\nEOF',
+    'chmod 755 %(installdir)s/bin/s3cmd', 
+    'mv  %(installdir)s/bin/restic_0.15.1_linux_amd64 %(installdir)s/bin/restic && chmod +x %(installdir)s/bin/restic',
+    f'mkdir -p %(installdir)s/share/man/man1 && cp %(builddir)s/s3cmd-{local_s3cmd_version}/s3cmd.1 %(installdir)s/share/man/man1',
+    f'mkdir -p %(installdir)s/share/licenses/s3cmd        && cp %(builddir)s/s3cmd-{local_s3cmd_version}/LICENSE        %(installdir)s/share/licenses/s3cmd',
+    f'mkdir -p %(installdir)s/share/licenses/python-magic && cp %(builddir)s/python-magic-{local_magic_version}/LICENSE %(installdir)s/share/licenses/python-magic',    
 ]
 
 sanity_check_paths = {
@@ -85,11 +102,7 @@ sanity_check_commands = [
 
 moduleclass = 'tools'
 
-modluafooter = """
-extensions( "rclone/%(rclone)s", "restic/%(restic)s", "s3cmd/%(s3cmd)s" )
-""" % {
-    'rclone': local_rclone_version,
-    'restic': local_restic_version,
-    's3cmd':  local_s3cmd_version,
-}
+modluafooter = f"""
+extensions( "rclone/{local_rclone_version}", "restic/{local_restic_version}", "s3cmd/{local_s3cmd_version}" )
+"""
 

--- a/easybuild/easyconfigs/l/lumio/LICENSE.md
+++ b/easybuild/easyconfigs/l/lumio/LICENSE.md
@@ -1,0 +1,8 @@
+# lumio license information
+
+The `lumio-conf` tool is licensed under an MIT license
+a copy of which can be found in the
+[LICENSE file in the LUMI-O-tools GitHub repository](https://github.com/Lumi-supercomputer/LUMI-O-tools/blob/main/LICENSE).
+
+After loading the module, the license file can also be found in the
+`$EBROOTLUMIO/share/licenses/lumio` directory.

--- a/easybuild/easyconfigs/l/lumio/README.md
+++ b/easybuild/easyconfigs/l/lumio/README.md
@@ -1,0 +1,17 @@
+# lumio technical documentation.
+
+This module is part of the modules that provide support for the LUMI-O
+object storage system. This module contains the configuration script where
+currently we expect that changes may be needed more often, while the
+[lumio-ext-tools](../lumio-ext-tools) module provides some basic commands
+that don't need frequent updates.
+
+-   [GitHub repository](https://github.com/Lumi-supercomputer/LUMI-O-tools)
+
+
+## EasyBuild
+
+### Version 1.0.0
+
+-   This EasyConfig is a development by CSC and LUST. All it needs to
+    do is download the repository and copy the files it needs.

--- a/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
@@ -38,7 +38,7 @@ key to the environment variables AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY respect
 https://lumidata.eu/ is also the s3 API endpoint for e.g raw API calls (not recommended)
 """
 
-local_lumi_conf_version = '0.1.1'
+local_lumi_conf_version = '0.1.2'
 
 toolchain = SYSTEM
 

--- a/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
@@ -1,0 +1,50 @@
+easyblock = 'MakeCp'
+
+name = 'lumio'
+version = "1.0.0"
+homepage="https://github.com/Lumi-supercomputer/LUMI-O-tools"
+whatis = [ 'Description: Basic tooling for LUMI-O. Provides the lumio-conf authentication script + rclone,s3cmd and restic' ]
+description = """
+    This module provides the command "lumio-conf" to authenticate to LUMI-O.
+    It also provides the tools rclone,s3cmd and restic for moving data to/from LUMI-O. 
+""" 
+
+usage = """
+Authenticate to LUMI-O
+    lumio-conf     
+
+The script will prompt you for project information and authentication keys which can be 
+found from https://auth.lumidata.eu. If the keys expire (Max duration for keys is 168h )
+or you need to switch the project, rerun the command.
+
+Two different rclone remotes are configured: lumi-o and lumi-pub 
+Data pushed to lumi-pub is publicly available using the URL: https://<Project number>.lumidata.eu/<bucket_name>/<object>
+
+To use restic, set the repository to s3:https://lumidata.eu/ and assign then access and secret key
+to the environment variables AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY respectively 
+
+    export AWS_ACCESS_KEY_ID=<MY_ACCESS_KEY>
+    export AWS_SECRET_ACCESS_KEY=<MY_SECRET_ACCESS_KEY>
+    restic -r s3:https://lumidata.eu/<bucket> init
+
+https://lumidata.eu/ is also the s3 API endpoint for e.g raw API calls (not recommended)
+"""
+
+moduleclass='tools'
+
+local_lumi_conf_version='0.1.1'
+
+toolchain = SYSTEM
+dependencies =   [
+('lumio-ext-tools','1.0.0')
+]
+source_urls =  ['https://github.com/Lumi-supercomputer/LUMI-O-tools/archive/refs/tags/']
+sources = [f'v{local_lumi_conf_version}.tar.gz']
+skipsteps = ['build']
+files_to_copy = [
+            (['lumio-conf'],   'bin')
+]
+sanity_check_paths= {
+            'files': ['bin/lumio-conf'],
+            'dirs':  []
+}

--- a/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
@@ -1,12 +1,19 @@
 easyblock = 'MakeCp'
 
-name = 'lumio'
-version = "1.0.0"
-homepage="https://github.com/Lumi-supercomputer/LUMI-O-tools"
-whatis = [ 'Description: Basic tooling for LUMI-O. Provides the lumio-conf authentication script + rclone,s3cmd and restic' ]
+name =    'lumio'
+version = '1.0.0'
+
+homepage = 'https://github.com/Lumi-supercomputer/LUMI-O-tools'
+
+whatis = [ 
+    'Description: Basic tooling for LUMI-O. Provides the lumio-conf authentication script + rclone,s3cmd and restic' 
+]
+
 description = """
-    This module provides the command "lumio-conf" to authenticate to LUMI-O.
-    It also provides the tools rclone,s3cmd and restic for moving data to/from LUMI-O. 
+This module provides the command "lumio-conf" to authenticate to LUMI-O.
+
+It also provides the tools rclone, s3cmd and restic for moving data to/from LUMI-O
+by loading a suitable lumio-ext-tools module. 
 """ 
 
 usage = """
@@ -18,10 +25,11 @@ found from https://auth.lumidata.eu. If the keys expire (Max duration for keys i
 or you need to switch the project, rerun the command.
 
 Two different rclone remotes are configured: lumi-o and lumi-pub 
-Data pushed to lumi-pub is publicly available using the URL: https://<Project number>.lumidata.eu/<bucket_name>/<object>
+Data pushed to lumi-pub is publicly available using the URL: 
+https://<Project number>.lumidata.eu/<bucket_name>/<object>
 
-To use restic, set the repository to s3:https://lumidata.eu/ and assign then access and secret key
-to the environment variables AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY respectively 
+To use restic, set the repository to s3:https://lumidata.eu/ and assign then access and secret
+key to the environment variables AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY respectively 
 
     export AWS_ACCESS_KEY_ID=<MY_ACCESS_KEY>
     export AWS_SECRET_ACCESS_KEY=<MY_SECRET_ACCESS_KEY>
@@ -30,21 +38,31 @@ to the environment variables AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY respectivel
 https://lumidata.eu/ is also the s3 API endpoint for e.g raw API calls (not recommended)
 """
 
-moduleclass='tools'
-
-local_lumi_conf_version='0.1.1'
+local_lumi_conf_version = '0.1.1'
 
 toolchain = SYSTEM
+
 dependencies =   [
-('lumio-ext-tools','1.0.0')
+    ('lumio-ext-tools','1.0.0')
 ]
+
 source_urls =  ['https://github.com/Lumi-supercomputer/LUMI-O-tools/archive/refs/tags/']
-sources = [f'v{local_lumi_conf_version}.tar.gz']
+sources =      [f'v{local_lumi_conf_version}.tar.gz']
+
 skipsteps = ['build']
+
 files_to_copy = [
-            (['lumio-conf'],   'bin')
+    (['lumio-conf'], 'bin'),
+    (['LICENSE'], 'share/licenses/lumio')
 ]
+
 sanity_check_paths= {
-            'files': ['bin/lumio-conf'],
-            'dirs':  []
+    'files': ['bin/lumio-conf'],
+    'dirs':  []
 }
+
+sanity_check_commands = [
+    'lumio-conf --help',
+]
+
+moduleclass='tools'

--- a/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
+++ b/easybuild/easyconfigs/l/lumio/lumio-1.0.0.eb
@@ -53,7 +53,7 @@ skipsteps = ['build']
 
 files_to_copy = [
     (['lumio-conf'], 'bin'),
-    (['LICENSE'], 'share/licenses/lumio')
+    (['LICENSE'], 'share/licenses/lumio'),
 ]
 
 sanity_check_paths= {

--- a/easybuild/easystacks/LUMI-22.08/production-system-22.08.yaml
+++ b/easybuild/easystacks/LUMI-22.08/production-system-22.08.yaml
@@ -25,4 +25,12 @@ software:
     toolchains:
       SYSTEM:
         versions: ['23.01']
-        
+  lumio-ext-tools:
+    toolchains:
+      SYSTEM:
+        versions: ['1.0.0']
+  lumio:
+    toolchains:
+      SYSTEM:
+        versions: ['1.0.0']
+  


### PR DESCRIPTION
Proposal for basic lumi-o tooling. 

So authentication script + restic,s3cmd and rclone

The basic tools consists of two modules, one module e.g lumio-ext-tools this one would provide restic,s3cmd and rclone (with the s3cmd patched ). Updates would probably be fairly infrequent, only if there are specific bugs in the tools, related to LUMI-O usage. This would then be the dependency for the lumio module which provides the authentication script itself. This meas that we could update the authentication script independently from the tools while still provide a controlled working bundle of tools + we only need two modules. The authentication script should be pretty safe to update live as it is interactive (requires to insert authentications keys on the command lines) and there is no support for non-interactivity. Very advanced users are then free to ignore the lumio-ext-tools module and load in whatever version for the tools they want but for most users, they can just load lumio and get started.

restic and rclone are static go binaries, s3cmd is python but during package installation absolute interpreter path is added. 
So this module should be safe to have always loadable. 


### s3cmd patch

The s3cmd normally requires `PYTHONPATH` to be set, which it would do using a module. This is a pretty safe addition as the installations does provide any python packages -> will not interfere with any other python modules / installations. So it might be overkill but I apply a (kind of hacky) patch so that `s3cmd` does not require   `PYTHONPATH` to be set -> user can no longer break the lumio module by messing up PYTHONPATH. If this is improbable the patch could also be dropped.  
