### PR TITLE
Feature/update gen cpe modulerc

### DIFF
--- a/CrayPE/CPEpackages_21.12.csv
+++ b/CrayPE/CPEpackages_21.12.csv
@@ -8,7 +8,7 @@ ATOMS,1.0.5
 PALS,1.1.3
 ATP,3.14.8
 CCDB,4.12.7
-Cray-dininst,10.1.0
+cray-dyninst,10.1.0
 CTI,2.15.8
 gdb4hpc,4.13.8
 STAT,4.11.8

--- a/CrayPE/CPEpackages_22.06.csv
+++ b/CrayPE/CPEpackages_22.06.csv
@@ -8,7 +8,7 @@ ATOMS,1.0.10
 PALS,1.1.8
 ATP,3.14.11
 CCDB,4.12.11
-Cray-dininst,12.1.0
+cray-dyninst,12.1.0
 CTI,2.15.12
 gdb4hpc,4.14.1
 sanitizers4hpc,1.0.0

--- a/CrayPE/CPEpackages_22.08.csv
+++ b/CrayPE/CPEpackages_22.08.csv
@@ -8,7 +8,7 @@ ATOMS,1.1.2
 PALS,1.2.0
 ATP,3.14.13
 CCDB,4.12.13
-Cray-dininst,12.1.1
+cray-dyninst,12.1.1
 CTI,2.15.13
 gdb4hpc,4.14.2
 sanitizers4hpc,1.0.1

--- a/scripts/lumitools/gen_CPE_modulerc.py
+++ b/scripts/lumitools/gen_CPE_modulerc.py
@@ -7,19 +7,25 @@
 #   * version : Release of the CPE to generate the file for.
 #
 
+import re
+
 def gen_CPE_modulerc( CPEpackages_dir, LMOD_dir, version ):
 
-    def write_package( fileH, PEpackage, module, package_versions ):
+    def write_package( fileH, PEpackage, module, package_versions, minv='00.00', maxv='99.99' ):
 
         # Note that if a particular PEpackage does not exist in package_versions, no
         # error is printed. This is done in this way to be able to cope with evolutions
         # in the packages while still having a single script that works for all as
         # those packages will now simply be skipped.
 
-        if PEpackage in package_versions:
-            version = package_versions[PEpackage]
-            fileH.write( 'module_version( \'%s/%s\', \'default\')\n' % (module, version) )
-
+        nonlocal version
+        
+        nversion = re.sub( '\D+', '', version )
+        nminv =    re.sub( '\D+', '', minv )
+        nmaxv =    re.sub( '\D+', '', maxv )
+        if nversion >= nminv and nversion <= nmaxv and PEpackage in package_versions:
+            mversion = package_versions[PEpackage]
+            fileH.write( f'module_version( \'{module}/{mversion}\', \'default\')\n' )
 
     #
     # Core of the gen_CPE_modulerc function
@@ -75,13 +81,23 @@ def gen_CPE_modulerc( CPEpackages_dir, LMOD_dir, version ):
     write_package( fileH, 'cpe-prgenv',           'PrgEnv-cray',              package_versions )
     write_package( fileH, 'cpe-prgenv',           'PrgEnv-gnu',               package_versions )
     write_package( fileH, 'cpe-prgenv',           'PrgEnv-aocc',              package_versions )
-    write_package( fileH, 'cpe-prgenv',           'PrgEnv-intel',             package_versions )
-    write_package( fileH, 'cpe-prgenv',           'PrgEnv-nvidia',            package_versions )
+    write_package( fileH, 'cpe-prgenv',           'PrgEnv-amd',               package_versions )
+    #write_package( fileH, 'cpe-prgenv',           'PrgEnv-intel',             package_versions )
+    #write_package( fileH, 'cpe-prgenv',           'PrgEnv-nvidia',            package_versions )
+    #write_package( fileH, 'cpe-prgenv',           'PrgEnv-nvhpc',             package_versions )
 
     write_package( fileH, 'CCE',                  'cce',                      package_versions )
     write_package( fileH, 'GCC',                  'gcc',                      package_versions )
     write_package( fileH, 'AOCC',                 'aocc',                     package_versions )
-    write_package( fileH, 'intel',                'intel',                    package_versions )
+    write_package( fileH, 'ROCM',                 'amd',                      package_versions )
+    #write_package( fileH, 'intel',                'intel',                    package_versions )
+
+    write_package( fileH, 'CCE',                  'cce-mixed',                package_versions, minv='22.06' )
+    write_package( fileH, 'GCC',                  'gcc_mixed',                package_versions, minv='22.06' )
+    write_package( fileH, 'AOCC',                 'aocc_mixed',               package_versions, minv='22.06' )
+    write_package( fileH, 'ROCM',                 'amd_mixed',                package_versions, minv='22.06' )
+
+    write_package( fileH, 'ROCM',                 'rocm',                     package_versions )
 
     write_package( fileH, 'craype',               'craype',                   package_versions )
     write_package( fileH, 'CPE',                  'cpe',                      package_versions )
@@ -93,7 +109,7 @@ def gen_CPE_modulerc( CPEpackages_dir, LMOD_dir, version ):
     write_package( fileH, 'MPICH',                'cray-mpich',               package_versions )
     write_package( fileH, 'MPICH',                'cray-mpich-abi',           package_versions )
     write_package( fileH, 'PMI',                  'cray-pmi',                 package_versions )
-    write_package( fileH, 'PMI',                  'cray-pmi-lib',             package_versions )
+    write_package( fileH, 'PMI',                  'cray-pmi-lib',             package_versions, maxv='22.06' )
     write_package( fileH, 'OpenSHMEMX',           'cray-openshmemx',          package_versions )
 
     write_package( fileH, 'FFTW',                 'cray-fftw',                package_versions )
@@ -109,6 +125,7 @@ def gen_CPE_modulerc( CPEpackages_dir, LMOD_dir, version ):
     write_package( fileH, 'CCDB',                 'cray-ccdb',                package_versions )
     write_package( fileH, 'CTI',                  'cray-cti',                 package_versions )
     write_package( fileH, 'DSMML',                'cray-dsmml',               package_versions )
+    write_package( fileH, 'cray-dyninst',         'cray-dyninst',             package_versions, minv='21.12' )
     write_package( fileH, 'jemalloc',             'cray-jemalloc',            package_versions )
     write_package( fileH, 'STAT',                 'cray-stat',                package_versions )
     write_package( fileH, 'craypkg-gen',          'craypkg-gen',              package_versions )
@@ -117,9 +134,8 @@ def gen_CPE_modulerc( CPEpackages_dir, LMOD_dir, version ):
 
     write_package( fileH, 'cray-python',          'cray-python',              package_versions )
     write_package( fileH, 'cray-R',               'cray-R',                   package_versions )
-    write_package( fileH, 'craype-dl-plugin-py3', 'craype-dl-plugin-py3',     package_versions )
+    write_package( fileH, 'craype-dl-plugin-py3', 'craype-dl-plugin-py3',     package_versions, maxv='21.08' )
 
-    # Grenoble-only?
     write_package( fileH, 'PALS',                 'cray-pals',                package_versions )
     write_package( fileH, 'PALS',                 'cray-libpals',             package_versions )
 


### PR DESCRIPTION
Update the make_CPE_mdoulerc.sh / gen_CPE_modulerc.py code to generate a more complete list of default modules, adding the mixed compiler modules from 22.06 on and removing one that is no longer used.

May need some further testing, and we need to figure out a procedure to update the generated files that are already on the system.