### PR TITLE
Improvement to the visibility hook: 

### DIFF
--- a/LMOD/SitePackage.lua
+++ b/LMOD/SitePackage.lua
@@ -783,11 +783,17 @@ local function is_visible_hook( modT )
         package.path = saved_path
 
         if modT.fn:find( 'cray/pe/lmod/modulefiles' ) or modT.fn:find( 'modules/CrayOverwrite' ) then
+            -- The module under investigation is a Cray PE module or one of our replacements.
             if CPEmodules[modT.sn] ~= nil then
+                -- We have version information for this module.
                 local module_version = modT.sn .. '/' .. CPEmodules[modT.sn]
                 if modT.fullName ~= module_version and not visibility_exceptions[ modT.fullName] then
                     modT.isVisible = false
                 end
+            else
+                -- We do not have version information about this module in the VisbilityHookData files,
+                -- so this is a module that does not appear in the current version of the LUMI stack.
+                modT.isVisible = false
             end
         end
 


### PR DESCRIPTION
Make sure that CPE modules that w…ere not yet known in the loaded version of the LUMI stack are also not displayed.

Note that for this to work the VisibilityHookData files for retired stacks that are currently aliased to a newer version should be those of the newer version, ideally with those modules that were not known in the old stack left out.
