### PR TITLE
Remove the warning about gcc/12.2.0. 

### DIFF
--- a/LMOD/admin.list
+++ b/LMOD/admin.list
@@ -38,13 +38,6 @@ module there is no guarantee that it will integrate properly with HPE Cray PE mo
 or work correctly in that environment. Note that HPE Cray PE programming environments
 up to at least 23.02 have only been tested with ROCm version prior to 5.3 by HPE.
 
-gcc/12.2.0:
-Other Cray sites have reported that gcc/12.2.0 can cause inconsistent results, especially
-at high optimisation levels. There are also known problems with the installation on LUMI 
-when used in combination with the Cray wrappers (at least for C++, and likely similar 
-problems for GNU Fortran) because at runtime it is forced to use libraries from an older 
-gcc version. Use at your own risk.
-
 Rust/1.60.0:
 The Rust 1.60.0 module is known to be faulty and will be removed from the system. As
 Rust is difficult to support and not a typical HPC language, it is removed from the


### PR DESCRIPTION
The part about optimisation is still relevant but annoying and the rest is irrelevant after the October-November 2023 system update.