### PR TITLE
Make EasyBuild-config better suited for use in the CPE containers.

### DIFF
--- a/docs/easybuild_setup.md
+++ b/docs/easybuild_setup.md
@@ -219,6 +219,20 @@ The following settings are made through environment variables:
     but it ensures that files produced by this option will not end up in our GitHub
     repository.
 
+  * `EASYBUILD_BUILDPATH` and `EASYBUILD_TMPDIR` are determined by the following strategy:
+
+     1. If the environment variable `EBU_WORKDIR` is set, that one is used as the base
+        for the directory names.
+
+     2. If we detect we are running in a singularity container, `/tmp/$USER` is used as
+        the base for the directory names.
+
+     3. If we are on a login node, we try to use $XDG_RUNTIME_DIR, and if that environment
+        variable isn't set, we try in `/tmp`.
+
+     4. Finally, if we are on a compute node we construct a subdirectory in `/tmp` based
+        on the Slurm job ID or user name.
+
 
 ### The EasyBuild-user mode
 
@@ -289,13 +303,27 @@ The following settings are made through environment variables:
 
     So currently the additional search paths in user mode are empty. 
 
+  * `EASYBUILD_BUILDPATH` and `EASYBUILD_TMPDIR` are determined by the following strategy:
+
+     1. If the environment variable `EBU_WORKDIR` is set, that one is used as the base
+        for the directory names.
+
+     2. If we detect we are running in a singularity container, `/tmp/$USER` is used as
+        the base for the directory names.
+
+     3. If we are on a login node, we try to use $XDG_RUNTIME_DIR, and if that environment
+        variable isn't set, we try in `/tmp`.
+
+     4. Finally, if we are on a compute node we construct a subdirectory in `/tmp` based
+        on the Slurm job ID or user name.
+
 There are two regular configuration files:
 
  1. The system ``easybuild-production.cfg`` is always read. In the current
     implementation it is assumed to be present.
 
  2. The user ``easybuild-user.cfg``(in ``UserRepo/easybuild/config`` in the user
-    direcgtory) is read next and meant for user-specific settings that should be
+    directory) is read next and meant for user-specific settings that should be
     read for all LUMI software stacks.
 
  3. Then the system ``easybuild-production-LUMI-yy.mm.cfg`` is read after, hence can be used

--- a/modules/EasyBuild-config/21.01.lua
+++ b/modules/EasyBuild-config/21.01.lua
@@ -194,7 +194,22 @@ local CPE_version =           lumi_stack_version:gsub( '.dev', '' )  -- Drop .de
 
 local workdir
 local cleandir = nil
-if ( get_hostname():find( 'uan' ) ) then
+local ebu_workdir = os.getenv( 'EBU_WORKDIR' ) or nil
+if ( ebu_workdir ~= nil ) then
+    
+    -- Work directory given by the user in the EBU_WORKDIR environment variable,
+    -- use that instead of the default strategies.
+
+    cleandir = ebu_workdir
+    workdir = ebu_workdir
+
+elseif ( isFile( '/.singularity.d/Singularity' ) ) then
+
+    -- We're in a singularity container. Count on a writable /tmp but not workding XDG_RUNTIME_DIR or so.
+    cleandir = pathJoin( '/tmp', os.getenv( 'USER' ) )
+    workdir = cleandir
+
+elseif ( get_hostname():find( 'uan' ) ) then
 
     -- We are running on the login nodes so we can use XDG_RUNTIME_DIR
     -- which is cleaned automatically at the end of the session
@@ -618,6 +633,11 @@ The module assumes the following environment variables:
   * EBU_USER_PREFIX: Prefix for the EasyBuild user installation. The default
     is $HOME/EasyBuild.
 
+The following environment variables are optional:
+  * EBU_WORKDIR: Directory to use for the EasyBuild build dir and tmp dir. 
+    The default is to use either $XDG_RUNTIME_DIR (outside a container on the login
+    nodes of LUMI) or a subdirectory in /tmp.
+
 The following user-specific directories and files are used by this module:
   * Directory for user EasyConfig files:      ]] .. user_easyconfigdir .. '\n' .. [[
   * EasyBuild user configuration files:       ]] .. user_configdir .. '\n' .. [[
@@ -694,6 +714,11 @@ the software stack it is needed to re-load this module (if it is not done automa
 After loading the module, it is possible to simply use the eb command without further
 need for long command line arguments to specify the configuration.
 
+The following environment variables are optional:
+  * EBU_WORKDIR: Directory to use for the EasyBuild build dir and tmp dir. 
+    The default is to use either $XDG_RUNTIME_DIR (outside a container on the login
+    nodes of LUMI) or a subdirectory in /tmp.
+
 ]]
 
 else
@@ -722,6 +747,11 @@ the modules are stored.
 
 After loading the module, it is possible to simply use the eb command without further
 need for long command line arguments to specify the configuration.
+
+The following environment variables are optional:
+  * EBU_WORKDIR: Directory to use for the EasyBuild build dir and tmp dir. 
+    The default is to use either $XDG_RUNTIME_DIR (outside a container on the login
+    nodes of LUMI) or a subdirectory in /tmp.
 
 ]]
 


### PR DESCRIPTION
To be deployed before deploying 23.12 or 24.03, doesn't need to wait for that.