### PR TITLE
Boost 25.03

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.88.0-cpeAMD-25.03.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.88.0-cpeAMD-25.03.eb
@@ -1,0 +1,85 @@
+# contributed by Luca Marsella (CSCS)
+# Adapted by Kurt Lust (kurt.lust@uantwerpen.be) for the LUMI consortium
+easyblock = 'EB_BoostCPE'
+
+local_bzip2_version =        '1.0.8'         # http://www.bzip.org/downloads.html
+local_ICU_version =          '76.1'          # http://site.icu-project.org/home
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+local_zstd_version =         '1.5.7'         # https://github.com/facebook/zstd/releases
+
+local_Boost_version =        '1.88.0'        # https://www.boost.org/
+
+name =    'Boost'
+version = local_Boost_version
+
+homepage = 'http://www.boost.org/'
+
+whatis = [
+    'Description: Boost provides free peer-reviewed portable C++ source libraries.'
+]
+
+description = """
+Boost provides free peer-reviewed portable C++ source libraries.
+
+We emphasize libraries that work well with the C++ Standard Library. Boost
+libraries are intended to be widely useful, and usable across a broad spectrum
+of applications. The Boost license encourages both commercial and non-commercial
+use.
+
+We aim to establish "existing practice" and provide reference implementations so
+that Boost libraries are suitable for eventual standardization. Ten Boost
+libraries are included in the C++ Standards Committee's Library Technical Report
+(TR1) and in the new C++11 Standard. C++11 also includes several more Boost
+libraries in addition to those from TR1. More Boost libraries are proposed for
+standardization in C++17.
+
+This module includes static and shared libraries, compiled with MPI support.
+The library boost_python is build for the system Python.
+
+This version of the module does not include support for Cray Python.
+The module does inlude single-threaded (suffix -x86) and multithreaded (suffix
+-mt-x86) versions of the libraries. The default names (without suffix) link
+to the multithreaded versions.
+"""
+
+software_license_urls = [
+    'https://www.boost.org/users/license.html',
+    f'https://github.com/boostorg/boost/blob/boost-{version}/LICENSE_1_0.txt',
+]
+
+toolchain = {'name': 'cpeAMD', 'version': '25.03'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': False}
+
+#https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
+sources =     ['%(namelower)s_%(version_major)s_%(version_minor)s_0.tar.bz2']
+checksums = ['46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b']
+
+builddependencies = [ # Create a reproducible build environment.
+    ('buildtools',   '%(toolchain_version)s',   '', True),
+]
+
+dependencies = [
+    ('bzip2', local_bzip2_version),
+    ('zlib',  local_zlib_version),
+    ('zstd',  local_zstd_version),
+    ('ICU',   local_ICU_version),
+]
+
+configopts = '--without-libraries=python'
+
+# Also build boost_mpi - not needed as we already set use_mpi to True
+# boost_mpi = True
+
+# Toolsets - Not needed as the EasyBlock recognizes the toolchain.
+# toolset = 'clang'
+# build_toolset = 'clang'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp LICENSE_1_0.txt README.md %(installdir)s/share/licenses/%(name)s',   
+]
+
+modextravars = {'BOOST_ROOT': '%(installdir)s'}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.88.0-cpeCray-25.03.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.88.0-cpeCray-25.03.eb
@@ -1,0 +1,89 @@
+# contributed by Luca Marsella (CSCS)
+# Adapted by Kurt Lust (kurt.lust@uantwerpen.be) for the LUMI consortium
+easyblock = 'EB_BoostCPE'
+
+local_bzip2_version =        '1.0.8'         # http://www.bzip.org/downloads.html
+local_ICU_version =          '76.1'          # http://site.icu-project.org/home
+#local_libunwind_version  =   '1.6.2'         # http://download.savannah.nongnu.org/releases/libunwind/
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+local_zstd_version =         '1.5.7'         # https://github.com/facebook/zstd/releases
+
+local_Boost_version =        '1.88.0'        # https://www.boost.org/
+
+name =    'Boost'
+version = local_Boost_version
+
+homepage = 'http://www.boost.org/'
+
+whatis = [
+    'Description: Boost provides free peer-reviewed portable C++ source libraries.'
+]
+
+description = """
+Boost provides free peer-reviewed portable C++ source libraries.
+
+We emphasize libraries that work well with the C++ Standard Library. Boost
+libraries are intended to be widely useful, and usable across a broad spectrum
+of applications. The Boost license encourages both commercial and non-commercial
+use.
+
+We aim to establish "existing practice" and provide reference implementations so
+that Boost libraries are suitable for eventual standardization. Ten Boost
+libraries are included in the C++ Standards Committee's Library Technical Report
+(TR1) and in the new C++11 Standard. C++11 also includes several more Boost
+libraries in addition to those from TR1. More Boost libraries are proposed for
+standardization in C++17.
+
+This module includes static and shared libraries, compiled with MPI support.
+The library boost_python is build for the system Python.
+
+This version of the module does not include support for Cray Python.
+The module does inlude single-threaded (suffix -x86) and multithreaded (suffix
+-mt-x86) versions of the libraries. The default names (without suffix) link
+to the multithreaded versions.
+"""
+
+software_license_urls = [
+    'https://www.boost.org/users/license.html',
+    f'https://github.com/boostorg/boost/blob/boost-{version}/LICENSE_1_0.txt',
+]
+
+toolchain = {'name': 'cpeCray', 'version': '25.03'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': True, 'cstd': 'c++11'}
+
+#https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
+sources =     ['%(namelower)s_%(version_major)s_%(version_minor)s_0.tar.bz2']
+checksums = ['46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b']
+
+builddependencies = [ # Create a reproducible build environment.
+    ('buildtools',   '%(toolchain_version)s',   '', True),
+]
+
+dependencies = [
+    ('bzip2', local_bzip2_version),
+    #('libunwind', local_libunwind_version),
+    ('zlib',  local_zlib_version),
+    ('zstd',  local_zstd_version),
+    ('ICU',   local_ICU_version),
+]
+
+configopts = '--without-libraries=python'
+
+prebuildopts = 'export CCC_OVERRIDE_OPTIONS="x--target=x86_64-pc-linux" && '
+
+# Also build boost_mpi - not needed as we already set use_mpi to True
+# boost_mpi = True
+
+# Toolsets - Not needed as the EasyBlock recognizes the toolchain.
+# toolset = 'clang'
+# build_toolset = 'clang'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp LICENSE_1_0.txt README.md %(installdir)s/share/licenses/%(name)s',   
+]
+
+modextravars = {'BOOST_ROOT': '%(installdir)s'}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.88.0-cpeGNU-25.03.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.88.0-cpeGNU-25.03.eb
@@ -1,0 +1,85 @@
+# contributed by Luca Marsella (CSCS)
+# Adapted by Kurt Lust (kurt.lust@uantwerpen.be) for the LUMI consortium
+easyblock = 'EB_BoostCPE'
+
+local_bzip2_version =        '1.0.8'         # http://www.bzip.org/downloads.html
+local_ICU_version =          '76.1'          # http://site.icu-project.org/home
+local_zlib_version =         '1.3.1'         # https://zlib.net/
+local_zstd_version =         '1.5.7'         # https://github.com/facebook/zstd/releases
+
+local_Boost_version =        '1.88.0'        # https://www.boost.org/
+
+name =    'Boost'
+version = local_Boost_version
+
+homepage = 'http://www.boost.org/'
+
+whatis = [
+    'Description: Boost provides free peer-reviewed portable C++ source libraries.'
+]
+
+description = """
+Boost provides free peer-reviewed portable C++ source libraries.
+
+We emphasize libraries that work well with the C++ Standard Library. Boost
+libraries are intended to be widely useful, and usable across a broad spectrum
+of applications. The Boost license encourages both commercial and non-commercial
+use.
+
+We aim to establish "existing practice" and provide reference implementations so
+that Boost libraries are suitable for eventual standardization. Ten Boost
+libraries are included in the C++ Standards Committee's Library Technical Report
+(TR1) and in the new C++11 Standard. C++11 also includes several more Boost
+libraries in addition to those from TR1. More Boost libraries are proposed for
+standardization in C++17.
+
+This module includes static and shared libraries, compiled with MPI support.
+The library boost_python is build for the system Python.
+
+This version of the module does not include support for Cray Python.
+The module does inlude single-threaded (suffix -x86) and multithreaded (suffix
+-mt-x86) versions of the libraries. The default names (without suffix) link
+to the multithreaded versions.
+"""
+
+software_license_urls = [
+    'https://www.boost.org/users/license.html',
+    f'https://github.com/boostorg/boost/blob/boost-{version}/LICENSE_1_0.txt',
+]
+
+toolchain = {'name': 'cpeGNU', 'version': '25.03'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': False}
+
+#https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.bz2
+source_urls = ['https://archives.boost.io/release/%(version)s/source/']
+sources =     ['%(namelower)s_%(version_major)s_%(version_minor)s_0.tar.bz2']
+checksums = ['46d9d2c06637b219270877c9e16155cbd015b6dc84349af064c088e9b5b12f7b']
+
+builddependencies = [ # Create a reproducible build environment.
+    ('buildtools',   '%(toolchain_version)s',   '', True),
+]
+
+dependencies = [ # Note that XZ, used in the EasyBuilders repository, comes in via zstd.
+    ('bzip2', local_bzip2_version),
+    ('zlib',  local_zlib_version),
+    ('zstd',  local_zstd_version),
+    ('ICU',   local_ICU_version),
+]
+
+configopts = '--without-libraries=python'
+
+# Also build boost_mpi - not needed as we already set use_mpi to True
+# boost_mpi = True
+
+# Toolsets - Not needed as the EasyBlock recognizes the toolchain.
+# toolset = 'gcc'
+# build_toolset = 'gcc'
+
+postinstallcmds = [
+    'mkdir -p %(installdir)s/share/licenses/%(name)s',
+    'cp LICENSE_1_0.txt README.md %(installdir)s/share/licenses/%(name)s',   
+]
+
+modextravars = {'BOOST_ROOT': '%(installdir)s'}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Updated boost to 1.88 and for the 25.03 stack.

The AOCC patch should no longer be needed, but could not test AOCC boost, so no updates for AOCC are included.