### PR TITLE
fix rocm easyconfigs. add one missing library path to env

### DIFF
--- a/easybuild/easyconfigs/r/rocm/rocm-6.3.4-extras.eb
+++ b/easybuild/easyconfigs/r/rocm/rocm-6.3.4-extras.eb
@@ -354,7 +354,7 @@ local_version_major_minor = '.'.join( version.split('.') )
 modextrapaths = {
     'CMAKE_PREFIX_PATH' : 'lib/lib/cmake/hip',
     'LD_LIBRARY_PATH': {
-        'paths':   ['lib', 'lib/rocprofiler', 'lib/roctracer'],
+        'paths':   ['lib', 'lib/rocprofiler', 'lib/roctracer','lib/rocprofiler-systems'],
         'prepend': True,
     },
     'PKG_CONFIG_PATH': 'lib/pkgconfig',

--- a/easybuild/easyconfigs/r/rocm/rocm-6.4.4.eb
+++ b/easybuild/easyconfigs/r/rocm/rocm-6.4.4.eb
@@ -361,7 +361,7 @@ local_version_major_minor = '.'.join( version.split('.') )
 modextrapaths = {
     'CMAKE_PREFIX_PATH' : 'lib/lib/cmake/hip',
     'LD_LIBRARY_PATH': {
-        'paths':   ['lib', 'lib/rocprofiler', 'lib/roctracer'],
+        'paths':   ['lib', 'lib/rocprofiler', 'lib/roctracer', 'lib/rocprofiler-systems'],
         'prepend': True,
     },
     'PKG_CONFIG_PATH': 'lib/pkgconfig',


### PR DESCRIPTION
add one missing path to the env setup by the module load. This enables rocprof-sys to find all the required libraries

